### PR TITLE
fix notebook build_ensemble typos

### DIFF
--- a/examples/borzoi_example_eqtl_chr10_116952944_T_C.ipynb
+++ b/examples/borzoi_example_eqtl_chr10_116952944_T_C.ipynb
@@ -188,7 +188,7 @@
     "    seqnn_model.build_slice(target_index)\n",
     "    if rc :\n",
     "        seqnn_model.strand_pair.append(slice_pair)\n",
-    "    seqnn_model.build_ensemble(rc, '0')\n",
+    "    seqnn_model.build_ensemble(rc, [0])\n",
     "    \n",
     "    models.append(seqnn_model)\n"
    ]

--- a/examples/borzoi_example_ipaqtl_chr10_116664061_G_A.ipynb
+++ b/examples/borzoi_example_ipaqtl_chr10_116664061_G_A.ipynb
@@ -188,7 +188,7 @@
     "    seqnn_model.build_slice(target_index)\n",
     "    if rc :\n",
     "        seqnn_model.strand_pair.append(slice_pair)\n",
-    "    seqnn_model.build_ensemble(rc, '0')\n",
+    "    seqnn_model.build_ensemble(rc, [0])\n",
     "    \n",
     "    models.append(seqnn_model)\n"
    ]

--- a/examples/borzoi_example_paqtl_chr1_236763042_A_G.ipynb
+++ b/examples/borzoi_example_paqtl_chr1_236763042_A_G.ipynb
@@ -190,7 +190,7 @@
     "    seqnn_model.build_slice(target_index)\n",
     "    if rc :\n",
     "        seqnn_model.strand_pair.append(slice_pair)\n",
-    "    seqnn_model.build_ensemble(rc, '0')\n",
+    "    seqnn_model.build_ensemble(rc, [0])\n",
     "    \n",
     "    models.append(seqnn_model)\n"
    ]

--- a/examples/borzoi_example_sqtl_chr9_135548708_G_C.ipynb
+++ b/examples/borzoi_example_sqtl_chr9_135548708_G_C.ipynb
@@ -188,7 +188,7 @@
     "    seqnn_model.build_slice(target_index)\n",
     "    if rc :\n",
     "        seqnn_model.strand_pair.append(slice_pair)\n",
-    "    seqnn_model.build_ensemble(rc, '0')\n",
+    "    seqnn_model.build_ensemble(rc, [0])\n",
     "    \n",
     "    models.append(seqnn_model)\n"
    ]


### PR DESCRIPTION
### Description of your changes

In the example notebooks, fixes a typo by passing the correct type of argument: the list of ints `[0]`, instead of the string `'0'` to `SeqNN.build_ensemble()`. The current argument results in an error, and `[0]` is as indicated in https://github.com/calico/baskerville/blob/0a3075fcf04cae747fdb1f090441f0c0ac514b90/src/baskerville/seqnn.py#L222

This closes #13. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation add / update

### (If applicable) How has this been tested?

I ran the notebooks and verified the cells containing these calls run with the fix. Without this fix, running these cells results in an error.
